### PR TITLE
Support iPod touch on iOS 7

### DIFF
--- a/lib/Woothee/OS.pm
+++ b/lib/Woothee/OS.pm
@@ -68,7 +68,7 @@ sub challenge_osx {
             $data = dataset("iPhone");
         }elsif (index($ua, "iPad;") > -1) {
             $data = dataset("iPad");
-        }elsif (index($ua, "iPod;") > -1) {
+        }elsif (index($ua, "iPod") > -1) {
             $data = dataset("iPod");
         }
     }

--- a/t/testsets/smartphone_ios.yaml
+++ b/t/testsets/smartphone_ios.yaml
@@ -19,6 +19,13 @@
   os: iPod
   category: smartphone
 
+# iPod(touch, iOS 7) + Safari
+- target: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53'
+  name: Safari
+  version: '7.0'
+  os: iPod
+  category: smartphone
+
 # iPhone + Chrome iOS
 - target: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; ja-jp) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3'
   name: Chrome


### PR DESCRIPTION
- iPod touch on iOS7 doesn't have `iPod;`, it has `iPod touch;`
- Test case is from https://github.com/woothee/woothee/pull/6

---

I don't know how to update submodule woothee because https://github.com/woothee/woothee/pull/6 is not merged yet.
I think other implementations should support this test case.
